### PR TITLE
feat: add multi-architecture Docker image support

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -58,6 +58,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add multi-architecture support for Docker images
- Build for both linux/amd64 and linux/arm64 platforms

## Benefits
- Images can now run on Apple Silicon (M1/M2/M3) Macs
- Support for ARM-based servers and devices
- Better compatibility across different platforms

## Changes
- Added `platforms: linux/amd64,linux/arm64` to Docker build step