### PR TITLE
chore: remove unused API proxy from nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -71,15 +71,6 @@ http {
             add_header Pragma "no-cache";
         }
 
-        # API proxy (if needed)
-        location /api/ {
-            proxy_pass https://api.simonjamesrowe.com/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
         # Handle React Router - serve index.html for all routes
         location / {
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Remove API proxy configuration from nginx.conf as it is no longer needed.