### PR TITLE
feat: use native ARM64 runners for multi-arch Docker builds

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -5,12 +5,14 @@ on:
       - master
       - main
 jobs:
-  docker-build:
-    name: Docker Build and Deploy to GHCR
+  version-and-release:
+    name: Version and Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,6 +32,24 @@ jobs:
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
+  build-docker-images:
+    name: Build Docker Images
+    needs: version-and-release
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -40,27 +60,72 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/simonjamesrowe/react-ui
-          tags: |
-            type=semver,pattern={{version}},value=${{ steps.tag_version.outputs.new_tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag_version.outputs.new_tag }}
-            type=semver,pattern={{major}},value=${{ steps.tag_version.outputs.new_tag }}
-            type=raw,value=latest
-          labels: |
-            org.opencontainers.image.title=react-ui
-            org.opencontainers.image.description=Personal portfolio/resume SPA built with React & TypeScript
-
-      - name: Build and push to GitHub Container Registry
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=react-ui
+            org.opencontainers.image.description=Personal portfolio/resume SPA built with React & TypeScript
+            org.opencontainers.image.version=${{ needs.version-and-release.outputs.new_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  create-manifests:
+    name: Create Multi-Arch Manifests
+    needs: [version-and-release, build-docker-images]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push versioned multi-arch manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }} \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-amd64 \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}
+
+      - name: Extract version components
+        id: version
+        run: |
+          VERSION=${{ needs.version-and-release.outputs.new_tag }}
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+
+          # Split version into components
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "full=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push major.minor manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/react-ui:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-amd64 \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/react-ui:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+      - name: Create and push major manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/react-ui:${{ steps.version.outputs.major }} \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-amd64 \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/react-ui:${{ steps.version.outputs.major }}
+
+      - name: Create and push latest manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/react-ui:latest \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-amd64 \
+            ghcr.io/simonjamesrowe/react-ui:${{ needs.version-and-release.outputs.new_tag }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/react-ui:latest


### PR DESCRIPTION
## Summary
Improves multi-arch Docker builds by using native ARM64 GitHub runners instead of QEMU emulation, following the pattern from backend-modulith.

## Changes
Restructured the workflow into 3 separate jobs:

### 1. Version and Release
- Creates semantic version tag
- Generates GitHub release
- Outputs version info for subsequent jobs

### 2. Build Docker Images (Matrix)
- Builds images in parallel using matrix strategy
- **amd64**: Built on `ubuntu-latest`
- **arm64**: Built on native `ubuntu-24.04-arm` runners
- Each architecture pushed with `-amd64` or `-arm64` suffix

### 3. Create Multi-Arch Manifests
- Combines arch-specific images into multi-arch manifests
- Creates tags: `X.Y.Z`, `X.Y`, `X`, `latest`
- Uses `docker manifest` commands for proper multi-arch support

## Benefits
- **Faster builds**: Native ARM64 hardware vs QEMU emulation (~5-10x faster)
- **Parallel execution**: Both architectures build simultaneously
- **More reliable**: Native builds avoid QEMU compatibility issues
- **Cleaner separation**: Version → Build → Manifest flow is easier to understand

## Technical Details
- Follows the same pattern as [backend-modulith#12](https://github.com/simonjamesrowe/backend-modulith/pull/12)
- Uses GitHub's native ARM64 runners (generally available since 2024)
- Maintains all existing semantic version tags
- Compatible with all container runtimes that support manifests

## Testing
The workflow will run on this branch to verify the multi-arch build works correctly.