### PR TITLE
feat: modernize markdown rendering and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,14 +10,3 @@ GA_TRACKING_TOKEN=UA-179384022-3
 
 # Hotjar tracking token
 HOT_JAR_TRACKING_TOKEN=2022739
-
-# Environment name (development, staging, production)
-ENVIRONMENT=production
-
-# APM server URL
-APM_URL=https://apm.simonjamesrowe.com
-
-# Elastic APM configuration
-ELASTIC_APM_SERVICE_NAME=react-ui
-ELASTIC_APM_SERVER_URL=https://apm.simonjamesrowe.com
-ELASTIC_APM_SERVICE_VERSION=1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+/.idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This Vite-powered React/TypeScript UI keeps feature code in `src/`, with views in `components/pages`, shared UI in `components/common`, Redux logic under `state/`, models in `model/`, and static assets in `assets/`. Service wrappers for APIs, analytics, and environment wiring live in `services/` (see `services/Environment.ts` for runtime configuration). Global HTML assets stay in `public/`, while container/runtime infrastructure (Dockerfile, `nginx.conf`, `server.js`, `skaffold.yaml`) sits at the repo root for deployment.
+
+## Build, Test, and Development Commands
+- `yarn dev` (or `npm run dev`): start the Vite dev server with hot-module reload at http://localhost:5173.
+- `yarn build`: produce the production bundle in `dist/`, ready for the NGINX/Express wrappers.
+- `yarn preview`: serve the built bundle locally to sanity-check Docker or CDN behavior.
+- `yarn test` / `yarn test:ui`: run Vitest in headless or UI mode with the Happy DOM environment.
+- `yarn lint`: enforce the ESLint + `@typescript-eslint` ruleset; the CI treats warnings as failures.
+- `yarn typecheck`: run `tsc --noEmit` to catch structural issues that linting might miss.
+
+## Coding Style & Naming Conventions
+Write modern function components with hooks; prefer composition over large container files. React components and TypeScript types use `PascalCase` (`BlogDetail.tsx`, `IProfile`), helpers and hooks use `camelCase`, and environment keys remain `UPPER_SNAKE_CASE`. Follow the existing 4-space indentation and double-quote import style. Let ESLint and the TypeScript compiler be the source of truth—do not bypass them with `// eslint-disable` unless you can point to an upstream issue.
+
+## Testing Guidelines
+Vitest plus `happy-dom` backs component tests; colocate specs as `*.test.tsx` alongside the component (e.g., `components/pages/Blog/Blog.test.tsx`). Mock HTTP via Axios adapters or service-level stubs, not by touching Redux directly. Target at least statement parity with the affected code and extend fixtures in `src/App.test.tsx` when exercising top-level routing. UI-heavy changes should also include `yarn test:ui` screenshots or notes so reviewers can replay the suite.
+
+## Commit & Pull Request Guidelines
+History follows Conventional Commits (`feat:`, `chore:`, `fix:`), as seen in `feat: use native ARM64 runners...`; match that format and scope component directories when possible (`feat(home): add CTA banner`). Pull requests must describe the user impact, reference issues (`Closes #123`), and attach before/after screenshots for UI updates. Include a checklist of commands you ran (`dev`, `build`, `test`) and call out any follow-up work to keep reviewers aligned.
+
+## Security & Configuration Tips
+All runtime secrets flow through `window.*` globals or `VITE_*` variables that feed `services/Environment.ts`. Update `public/environment/config.js` or deployment manifests instead of hardcoding tokens, and never commit concrete API keys. Validate third-party script additions with the repo OWNERS before merging to keep analytics and APM payloads compliant.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,11 +8,6 @@ cat > /usr/share/nginx/html/environment/config.js <<EOF
 window.API_URL = "${API_URL:-https://api.simonjamesrowe.com}";
 window.GA_TRACKING_TOKEN = "${GA_TRACKING_TOKEN:-UA-179384022-3}";
 window.HOT_JAR_TRACKING_TOKEN = "${HOT_JAR_TRACKING_TOKEN:-2022739}";
-window.ENVIRONMENT = "${ENVIRONMENT:-production}";
-window.APM_URL = "${APM_URL:-https://apm.simonjamesrowe.com}";
-window.ELASTIC_APM_SERVICE_NAME = "${ELASTIC_APM_SERVICE_NAME:-react-ui}";
-window.ELASTIC_APM_SERVER_URL = "${ELASTIC_APM_SERVER_URL:-${APM_URL:-https://apm.simonjamesrowe.com}}";
-window.ELASTIC_APM_SERVICE_VERSION = "${ELASTIC_APM_SERVICE_VERSION:-1.0.0}";
 EOF
 
 echo "Generated environment configuration:"

--- a/index.html
+++ b/index.html
@@ -8,6 +8,19 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <script src="/environment/config.js" onerror="console.log('Config file not loaded, using defaults')"></script>
+    <script>
+      (function () {
+        const fallbackApiUrl = "https://api.simonjamesrowe.com";
+        const envApiUrl = "%VITE_API_URL%" || "";
+        if (
+          envApiUrl &&
+          envApiUrl !== "undefined" &&
+          (!window.API_URL || window.API_URL === fallbackApiUrl)
+        ) {
+          window.API_URL = envApiUrl;
+        }
+      })();
+    </script>
     <title>React App</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@elastic/apm-rum": "^5.16.0",
-    "@elastic/apm-rum-react": "^2.0.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
@@ -52,9 +50,11 @@
     "react-syntax-highlighter": "^15.5.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.21.1",
     "@types/express": "^4.17.21",
     "@types/intro.js": "^5.1.5",
     "@types/node": "^20.14.9",

--- a/public/environment/config.js
+++ b/public/environment/config.js
@@ -3,11 +3,3 @@
 window.API_URL = window.API_URL || "https://api.simonjamesrowe.com";
 window.GA_TRACKING_TOKEN = window.GA_TRACKING_TOKEN || "UA-179384022-3";
 window.HOT_JAR_TRACKING_TOKEN = window.HOT_JAR_TRACKING_TOKEN || "2022739";
-window.ENVIRONMENT = window.ENVIRONMENT || "development";
-window.APM_URL = window.APM_URL || "https://apm.simonjamesrowe.com";
-
-// Additional config for development
-window.ELASTIC_APM_SERVICE_NAME = window.ELASTIC_APM_SERVICE_NAME || "react-ui";
-window.ELASTIC_APM_SERVER_URL = window.ELASTIC_APM_SERVER_URL || window.APM_URL;
-window.ELASTIC_APM_SERVICE_VERSION = window.ELASTIC_APM_SERVICE_VERSION || "1.0.0";
-window.ELASTIC_APM_ENVIRONMENT = window.ELASTIC_APM_ENVIRONMENT || window.ENVIRONMENT;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import $ from 'jquery'
 import BlogDetail from "./components/pages/Blog/BlogDetail";
 import MetaTags from 'react-meta-tags';
-import { init as initApm } from '@elastic/apm-rum'
 
 interface IAppProps {
     loading: boolean,
@@ -36,18 +35,9 @@ const App = (props: IAppProps) => {
     }, []);
 
     const mobile = useMediaQuery("(max-width:991px)");
-    const [loading, setLoading] = React.useState<boolean>(
-true
-    );
+    const [loading, setLoading] = React.useState<boolean>(true);
 
-    const apm = initApm({
-        serviceName: 'react-ui',
-        serverUrl: properties.apmUrl,
-        environment: properties.environment
-    })
-
-
-    const onScroll = (event: any) => {
+    const onScroll = () => {
         const scrolled = window.scrollY;
         if (scrolled > 600) {$('.bottom_top').addClass("active");}
         if (scrolled < 600) {$('.bottom_top').removeClass("active");}
@@ -58,9 +48,12 @@ true
         window.addEventListener("scroll", onScroll);
         props.getProfile();
         props.getAllSocialMedia();
+        return () => {
+            window.removeEventListener("scroll", onScroll);
+        };
     }, []);
 
-    const scrollToTop = (event: any) => {
+    const scrollToTop = () => {
         $("html, body").animate({ scrollTop: "0" },  500);
     }
     const toggleMenu = () => {
@@ -69,7 +62,7 @@ true
 
     return (
         <>
-            <Router>
+            <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
                     {(loading || !props.profile) && (
                         <div className="preloader">
                             <div className="status"><img src={loader} id="preloader_image"
@@ -130,5 +123,3 @@ export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(App);
-
-

--- a/src/components/common/CodeBlock.tsx
+++ b/src/components/common/CodeBlock.tsx
@@ -1,18 +1,35 @@
 import React from "react";
 import {Prism as SyntaxHighlighter} from "react-syntax-highlighter";
 import {coy} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {Components} from "react-markdown";
 
-interface IProps {
-    value: string;
-    language: string;
-}
+const CodeBlock: Components["code"] = ({
+    inline,
+    className,
+    children,
+    node: _node,
+    ...props
+}) => {
+    const match = /language-(\w+)/.exec(className ?? "");
+    if (!inline && match) {
+        const content = String(children ?? "").replace(/\n$/, "");
+        return (
+            <SyntaxHighlighter
+                language={match[1]}
+                style={coy}
+                PreTag="div"
+                {...props}
+            >
+                {content}
+            </SyntaxHighlighter>
+        );
+    }
 
-const CodeBlock = ({value,language} : IProps) => {
     return (
-        <SyntaxHighlighter language={language} style={coy}>
-            {value}
-        </SyntaxHighlighter>
+        <code className={className} {...props}>
+            {children}
+        </code>
     );
-}
+};
 
 export {CodeBlock};

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -4,7 +4,6 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {IProfile} from "../../model/Profile";
 import {CmsImage} from "./CmsImage";
 import {HashLink as Link} from 'react-router-hash-link';
-import {Link as RealLink} from 'react-router-dom';
 import blogicon from "../../assets/images/blogicon.svg"
 
 interface IProps {
@@ -35,7 +34,7 @@ const SideBar = ({socialMedias, profile, toggleMenu}: IProps) => {
 										<svg className="nav_about_svg" width="26px" height="26px">
 											<defs>
 											<filter id="Filter_0">
-												<feFlood flood-color="rgb(255, 74, 74)" flood-opacity="1"
+												<feFlood floodColor="rgb(255, 74, 74)" floodOpacity="1"
                                                          result="floodOut"/>
 												<feComposite operator="atop" in="floodOut" in2="SourceGraphic"
                                                              result="compOut"/>
@@ -44,7 +43,7 @@ const SideBar = ({socialMedias, profile, toggleMenu}: IProps) => {
 
 											</defs>
 											<g filter="url(#Filter_0)">
-											<path fill-rule="evenodd" fill="rgb(14, 15, 33)"
+											<path fillRule="evenodd" fill="rgb(14, 15, 33)"
                                                   d="M21.937,13.863 L4.063,13.863 L4.063,7.776 L21.937,7.776 L21.937,13.863 ZM6.094,11.832 L19.906,11.832 L19.906,9.807 L6.094,9.807 L6.094,11.832 ZM21.937,3.866 L4.063,3.866 L4.063,5.897 L21.937,5.897 L21.937,3.866 ZM21.937,17.767 L12.188,17.767 L12.188,19.799 L21.937,19.799 L21.937,17.767 ZM10.156,21.830 L4.063,21.830 L4.063,15.742 L10.156,15.742 L10.156,21.830 ZM6.094,19.799 L8.125,19.799 L8.125,17.773 L6.094,17.773 L6.094,19.799 ZM22.953,26.000 L3.047,26.000 C1.367,26.000 0.000,24.633 0.000,22.953 L0.000,3.047 C0.000,1.367 1.367,0.000 3.047,0.000 L22.953,0.000 C24.633,0.000 26.000,1.367 26.000,3.047 L26.000,22.953 C26.000,24.633 24.633,26.000 22.953,26.000 L22.953,26.000 ZM3.047,2.031 C2.487,2.031 2.031,2.487 2.031,3.047 L2.031,22.953 C2.031,23.513 2.487,23.969 3.047,23.969 L22.953,23.969 C23.513,23.969 23.969,23.513 23.969,22.953 L23.969,3.047 C23.969,2.487 23.513,2.031 22.953,2.031 L3.047,2.031 Z"/>
 											</g>
 										</svg>
@@ -55,7 +54,7 @@ const SideBar = ({socialMedias, profile, toggleMenu}: IProps) => {
 										<svg className="nav_about_svg" width="26px" height="26px">
 											<defs>
 											<filter>
-												<feFlood flood-color="rgb(255, 74, 74)" flood-opacity="1"
+												<feFlood floodColor="rgb(255, 74, 74)" floodOpacity="1"
                                                          result="floodOut"/>
 												<feComposite operator="atop" in="floodOut" in2="SourceGraphic"
                                                              result="compOut"/>
@@ -64,7 +63,7 @@ const SideBar = ({socialMedias, profile, toggleMenu}: IProps) => {
 
 											</defs>
 											<g filter="url(#Filter_0)">
-											<path fill-rule="evenodd" fill="rgb(14, 15, 33)"
+											<path fillRule="evenodd" fill="rgb(14, 15, 33)"
                                                   d="M21.937,13.863 L4.063,13.863 L4.063,7.776 L21.937,7.776 L21.937,13.863 ZM6.094,11.832 L19.906,11.832 L19.906,9.807 L6.094,9.807 L6.094,11.832 ZM21.937,3.866 L4.063,3.866 L4.063,5.897 L21.937,5.897 L21.937,3.866 ZM21.937,17.767 L12.188,17.767 L12.188,19.799 L21.937,19.799 L21.937,17.767 ZM10.156,21.830 L4.063,21.830 L4.063,15.742 L10.156,15.742 L10.156,21.830 ZM6.094,19.799 L8.125,19.799 L8.125,17.773 L6.094,17.773 L6.094,19.799 ZM22.953,26.000 L3.047,26.000 C1.367,26.000 0.000,24.633 0.000,22.953 L0.000,3.047 C0.000,1.367 1.367,0.000 3.047,0.000 L22.953,0.000 C24.633,0.000 26.000,1.367 26.000,3.047 L26.000,22.953 C26.000,24.633 24.633,26.000 22.953,26.000 L22.953,26.000 ZM3.047,2.031 C2.487,2.031 2.031,2.487 2.031,3.047 L2.031,22.953 C2.031,23.513 2.487,23.969 3.047,23.969 L22.953,23.969 C23.513,23.969 23.969,23.513 23.969,22.953 L23.969,3.047 C23.969,2.487 23.513,2.031 22.953,2.031 L3.047,2.031 Z"/>
 											</g>
 										</svg>
@@ -198,8 +197,8 @@ const SideBar = ({socialMedias, profile, toggleMenu}: IProps) => {
                         </div>
                         <ul className="social_list">
                             {socialMedias.map(socialMedia => (
-                                <li>
-                                    <a href={socialMedia.link} className="siderbar_icon">
+                                <li key={socialMedia.link}>
+                                    <a href={socialMedia.link} className="siderbar_icon" rel="noreferrer" target="_blank">
                             <span className="first_icon"><FontAwesomeIcon icon={getMediaIcon(socialMedia.type)!!}
                                                                           className={getMediaClass(socialMedia.type)}/></span>
                                         <span className="second_icon"><FontAwesomeIcon

--- a/src/components/common/Tour.tsx
+++ b/src/components/common/Tour.tsx
@@ -21,7 +21,8 @@ const Tour = ({simulateSearch, isRunning, finishSimulation}: ITourProps) => {
 
     React.useEffect(() => {
         Axios.get<TourStep[]>(`${properties.apiUrl}/tour-steps`).then(response => {
-            setSteps(response.data.sort((x, y) => x.order - y.order).map(mapStep))
+            const orderedSteps = [...response.data].sort((x, y) => x.order - y.order).map(mapStep);
+            setSteps(orderedSteps);
         })
     }, []);
 

--- a/src/components/common/markdownComponents.tsx
+++ b/src/components/common/markdownComponents.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import {Components} from "react-markdown";
+
+const ExternalLink: Components["a"] = ({node: _node, ...props}) => (
+    <a {...props} target={props.target ?? "_blank"} rel={props.rel ?? "noreferrer"} />
+);
+
+export {ExternalLink};

--- a/src/components/pages/Blog/BlogDetail.tsx
+++ b/src/components/pages/Blog/BlogDetail.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
 import {CmsImage} from "../../common/CmsImage";
 import {properties} from "../../../services/Environment";
 import {IBlog} from "../../../model/Blog";
@@ -12,6 +13,7 @@ import {IApplicationState} from "../../../state/Store";
 import {connect} from "react-redux";
 import {ClosableHeader} from "../../common/CloseableHeader";
 import {CodeBlock} from "../../common/CodeBlock";
+import {ExternalLink} from "../../common/markdownComponents";
 
 interface IProps {
     blog: IBlog,
@@ -65,12 +67,12 @@ const BlogDetail = ({blog, getOneBlog}: IProps) => {
 
                                                 <ReactMarkdown
                                                     className="blog_markdown"
-                                                    source={blog.content}
-                                                    transformImageUri={imageUrl}
-                                                    linkTarget="_blank"
-                                                    allowDangerousHtml={true}
-                                                    renderers={{ code: CodeBlock }}
-                                                />
+                                                    urlTransform={imageUrl}
+                                                    rehypePlugins={[rehypeRaw]}
+                                                    components={{ code: CodeBlock, a: ExternalLink }}
+                                                >
+                                                    {blog.content ?? ""}
+                                                </ReactMarkdown>
 
                                             </div>
                                         </div>
@@ -101,5 +103,3 @@ const mapDispatchToProps = (dispatch: any) => {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(BlogDetail);
-
-

--- a/src/components/pages/Blog/BlogVertical.tsx
+++ b/src/components/pages/Blog/BlogVertical.tsx
@@ -33,13 +33,13 @@ const BlogVertical = ({blog}: Props) => {
                     </span>
 
                     <h4 className="blog_heading">
-                        <a href="blog.html">{blog.title}</a>
+                        <span>{blog.title}</span>
                     </h4>
                     <p>{blog.shortDescription}</p>
                     <div className="blog_readmore">
-                        <a href="blog.html" className="readmore_btn">Read
-                            More <FontAwesomeIcon
-                                icon={faUserEdit}/></a>
+                        <span className="readmore_btn">
+                            Read More <FontAwesomeIcon icon={faUserEdit}/>
+                        </span>
                     </div>
                 </div>
             </div>
@@ -49,4 +49,3 @@ const BlogVertical = ({blog}: Props) => {
 }
 
 export {BlogVertical}
-

--- a/src/components/pages/Blog/index.tsx
+++ b/src/components/pages/Blog/index.tsx
@@ -38,7 +38,7 @@ const Blog = (props: IBlogProps) => {
                                     </div>
                                 </div>
                                 {props.blogs.map((blog, i) => (
-                                    <>
+                                    <React.Fragment key={`${blog.id}-${i}`}>
                                         {(i % 6 == 0 || i % 6 == 5) && (
                                             <div className="col-md-12 col-lg-4">
                                                 <BlogVertical blog={blog}/>
@@ -60,7 +60,7 @@ const Blog = (props: IBlogProps) => {
                                                 )}
                                             </div>
                                         )}
-                                    </>
+                                    </React.Fragment>
                                 ))}
                             </div>
                         </div>
@@ -84,6 +84,5 @@ const mapDispatchToProps = (dispatch: any) => {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Blog);
-
 
 

--- a/src/components/pages/Home/Contact.tsx
+++ b/src/components/pages/Home/Contact.tsx
@@ -219,7 +219,7 @@ const Contact = ({profile}: IProps) => {
                                                 <FontAwesomeIcon icon={faPhone} size={"3x"}/>
                                             </div>
                                             <h2 className="footer_heading">Phone</h2>
-                                            <p><a href="javascript:;">{profile.phoneNumber}</a></p>
+                                            <p><a href={`tel:${profile.phoneNumber}`}>{profile.phoneNumber}</a></p>
 
                                         </div>
                                     </div>
@@ -229,8 +229,10 @@ const Contact = ({profile}: IProps) => {
                                                 <FontAwesomeIcon icon={faMailBulk} size={"3x"}/>
                                             </div>
                                             <h2 className="footer_heading">Email</h2>
-                                            <p><a href="javascript:;">{profile.primaryEmail}</a></p>
-                                            <p><a href="javascript:;">{profile.secondaryEmail}</a></p>
+                                            <p><a href={`mailto:${profile.primaryEmail}`}>{profile.primaryEmail}</a></p>
+                                            {profile.secondaryEmail && (
+                                                <p><a href={`mailto:${profile.secondaryEmail}`}>{profile.secondaryEmail}</a></p>
+                                            )}
                                         </div>
                                     </div>
 

--- a/src/components/pages/Home/JobDate.tsx
+++ b/src/components/pages/Home/JobDate.tsx
@@ -8,7 +8,7 @@ interface IProps {
 
 const JobDate = ({job} : IProps) => {
     return (
-        <div className="col-lg-4 col-md-4 col-sm-4 col-12 padding-0 w-100">
+        <div className="col-lg-4 col-md-4 col-sm-4 col-12 padding-0">
             <div className="ex_leftside">
                 <h1>{Moment(job.startDate).format("YYYY")}</h1>
                 <h4>{Moment(job.startDate).format("MMM")} to {job.endDate ? Moment(job.endDate)?.format("MMM") : ""}</h4>

--- a/src/components/pages/Home/JobDetail.tsx
+++ b/src/components/pages/Home/JobDetail.tsx
@@ -8,6 +8,7 @@ import Moment from "moment";
 import {ClosableHeader} from "../../common/CloseableHeader";
 import {Card, Tab, Tabs} from "react-bootstrap";
 import {properties} from "../../../services/Environment";
+import {ExternalLink} from "../../common/markdownComponents";
 
 interface IProps {
     open: boolean;
@@ -63,7 +64,9 @@ const JobDetail = ({open, job, close}: IProps) => {
                                         <div className="blog_wrapper">
                                             <div className="blog_data">
                                                 <div className="blog_content blog_markdown">
-                                                    <ReactMarkdown source={job.longDescription}/>
+                                                    <ReactMarkdown components={{ a: ExternalLink }}>
+                                                        {job.longDescription ?? ""}
+                                                    </ReactMarkdown>
                                                 </div>
                                             </div>
                                         </div>
@@ -72,8 +75,8 @@ const JobDetail = ({open, job, close}: IProps) => {
                             </Tab>
                             <Tab eventKey="skills" title="Skills">
                                 <div className="row">
-                                    {job.skills.sort((x, y) => (x.name > y.name) ? 1 : -1).map(skill => (
-                                        <div className="col-md-6 col-lg-4 col-sm-12">
+                                    {[...job.skills].sort((x, y) => (x.name > y.name) ? 1 : -1).map(skill => (
+                                        <div className="col-md-6 col-lg-4 col-sm-12" key={skill.id}>
                                             <Card>
                                                 <Card.Body>
                                                     <Card.Text><CmsImage src={skill.image}

--- a/src/components/pages/Home/JobHeadline.tsx
+++ b/src/components/pages/Home/JobHeadline.tsx
@@ -18,7 +18,7 @@ const JobHeadline = ({job}: IProps) => {
     }
 
     return (
-        <div className="col-lg-8 col-md-8 col-sm-8 col-12 w-100">
+        <div className="col-lg-8 col-md-8 col-sm-8 col-12">
             <div className="ex_rightside">
                 <h4>
                     <a title={job.company} href={job.companyUrl} target="_blank" onClick={(event) => event.stopPropagation() }>

--- a/src/components/pages/Home/Profile.tsx
+++ b/src/components/pages/Home/Profile.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 import {IProfile} from "../../../model/Profile";
 import {getMediaIcon, ISocialMedia} from "../../../model/SocialMedia";
 import {properties} from "../../../services/Environment";
+import {ExternalLink} from "../../common/markdownComponents";
 
 
 interface IProfileProperties {
@@ -53,8 +54,11 @@ const Profile = ({profile, socialMedias}: IProfileProperties) => {
 
                                             <ul className="social-links">
                                                 {socialMedias.map(socialMedia =>
-                                                    <li><a className="tip social-button" href={socialMedia.link}>
-                                                        <FontAwesomeIcon icon={getMediaIcon(socialMedia.type)!!} /></a></li>
+                                                    <li key={socialMedia.link}>
+                                                        <a className="tip social-button" href={socialMedia.link}>
+                                                            <FontAwesomeIcon icon={getMediaIcon(socialMedia.type)!!} />
+                                                        </a>
+                                                    </li>
                                                 )}
 
                                             </ul>
@@ -70,7 +74,9 @@ const Profile = ({profile, socialMedias}: IProfileProperties) => {
                                         </div>
                                     </div>
                                     <h2 className="about_tophead tour-about">{profile.headline}</h2>
-                                    <ReactMarkdown source={profile.description} />
+                                    <ReactMarkdown components={{ a: ExternalLink }}>
+                                        {profile.description ?? ""}
+                                    </ReactMarkdown>
 
                                     <div className="anout_section_btn">
                                         <a href={properties.apiUrl + "/resume"} className="portfolio_btn btn_yellow">

--- a/src/components/pages/Home/Resume.tsx
+++ b/src/components/pages/Home/Resume.tsx
@@ -58,7 +58,7 @@ const Resume = ({jobs}: IProps) => {
                         </div>
                         <div className="row">
                             {jobs.map((job, i) => (
-                                <div className={`col-lg-6 col-md-12 ${i ==0 ? "": ""}`}>
+                                <div className="col-lg-6 col-md-12" key={job._id}>
                                     <div className={experienceBoxStyle(i)}>
                                         <div className="row pointer tour-experience-1"
                                              onClick={() => expandJobDrawer(job._id, job.title)}>
@@ -69,8 +69,12 @@ const Resume = ({jobs}: IProps) => {
                             ))}
                         </div>
                         {jobs.map(job => (
-                            <JobDetail open={jobsDraw[job._id]} job={job}
-                                       close={() => collapseJobDrawer(job._id)}/>
+                            <JobDetail
+                                key={`drawer-${job._id}`}
+                                open={jobsDraw[job._id]}
+                                job={job}
+                                close={() => collapseJobDrawer(job._id)}
+                            />
                         ))}
                     </div>
                 </div>

--- a/src/components/pages/Home/SkillGroup.tsx
+++ b/src/components/pages/Home/SkillGroup.tsx
@@ -1,14 +1,14 @@
-import React, {Ref, RefObject} from "react"
+import React from "react"
 import {getVariant, ISkill, ISkillGroup} from "../../../model/Skill";
 import SwipeableDrawer from "@mui/material/SwipeableDrawer";
 import {CmsImage} from "../../common/CmsImage";
 import {Card, ProgressBar} from "react-bootstrap";
 import ReactMarkdown from "react-markdown";
+import {ExternalLink} from "../../common/markdownComponents";
 import {ClosableHeader} from "../../common/CloseableHeader";
 import {useLocation} from "react-router-dom";
 import $ from 'jquery'
 import {IJob} from "../../../model/Job";
-import {properties} from "../../../services/Environment";
 import Moment from "moment";
 
 interface ISkillGroupProps {
@@ -32,8 +32,7 @@ const SkillGroup = ({open, skillGroup, close, jobs}: ISkillGroupProps) => {
     }
 
     const scrollToSkill = () => {
-        if (open && location.hash && skillGroup.skills.find(skill => skill.id == location.hash.substr(1))) {
-            const selectedSkillId = location.hash.substr(1);
+        if (open && location.hash && skillGroup.skills.find(skill => skill.id === location.hash.substr(1))) {
             setTimeout(() => {
                 const skillId = window.location.hash.substr(1);
                 const skillGroup = window.location.pathname.substr(window.location.pathname.lastIndexOf("/") + 1);
@@ -68,25 +67,30 @@ const SkillGroup = ({open, skillGroup, close, jobs}: ISkillGroupProps) => {
                                     </div>
                                     <h1 className="port_heading">{skillGroup.name}</h1>
                                     <br/>
-                                    <ReactMarkdown source={skillGroup.description!!}/>
+                                    <ReactMarkdown components={{ a: ExternalLink }}>
+                                        {skillGroup.description ?? ""}
+                                    </ReactMarkdown>
                                 </div>
                             </div>
                         </div>
                         <div className="row">
                             {skillGroup.skills.map(skill => (
-                                <div className="col-lg-6 col-md-6 text-center">
+                                <div className="col-lg-6 col-md-6 text-center" key={skill.id}>
                                     <div className="port_services_box_wrapper">
                                         <div className="port_services_box" id={skill.id}>
                                             <CmsImage src={skill.image} type={"thumbnail"}/>
                                             <h2 className="project_heading">{skill.name}</h2>
                                             <ProgressBar now={skill.rating * 10} variant={getVariant(skill.rating)}/>
                                             <br/>
-                                            <ReactMarkdown
-                                                source={skill.description!!}
-                                                linkTarget="_blank" />
+                                            <ReactMarkdown components={{ a: ExternalLink }}>
+                                                {skill.description ?? ""}
+                                            </ReactMarkdown>
                                             <hr />
                                             {getJobsWithSkill(skill).map(job => (
-                                                <Card title={`${job.company} - ${Moment(job.startDate).format("MMM-YYYY")} to ${job.endDate ? Moment(job.endDate)?.format("MMM-YYYY") : "Now"}`}>
+                                                <Card
+                                                    key={`${skill.id}-${job._id}`}
+                                                    title={`${job.company} - ${Moment(job.startDate).format("MMM-YYYY")} to ${job.endDate ? Moment(job.endDate)?.format("MMM-YYYY") : "Now"}`}
+                                                >
                                                     <Card.Body>
                                                         <Card.Text><CmsImage src={job.companyImage} type={"thumbnail"}/> {job.title}</Card.Text>
                                                     </Card.Body>

--- a/src/model/TourStep.tsx
+++ b/src/model/TourStep.tsx
@@ -3,6 +3,7 @@ import React, {ReactElement} from "react";
 import Tour from "../components/common/Tour";
 import {properties} from "../services/Environment";
 import ReactMarkdown from "react-markdown";
+import {ExternalLink} from "../components/common/markdownComponents";
 
 export interface TourStep {
     title: string;
@@ -28,7 +29,11 @@ export const mapStep = (tourStep: TourStep) : Step => {
     return {
       element : tourStep.selector,
       title: `${image} ${tourStep.title}`,
-      intro: <ReactMarkdown source={tourStep.description} linkTarget="_blank"/>,
+      intro: (
+          <ReactMarkdown components={{ a: ExternalLink }}>
+              {tourStep.description ?? ""}
+          </ReactMarkdown>
+      ),
       position: tourStep.position
     };
 }

--- a/src/services/Environment.ts
+++ b/src/services/Environment.ts
@@ -2,16 +2,12 @@ interface IAppProps {
     apiUrl: string;
     gaTrackingToken: string;
     hotJarTrackingToken: string;
-    environment: string;
-    apmUrl: string;
 }
 
 const properties: IAppProps = {
     apiUrl: window.API_URL || import.meta.env.VITE_API_URL || "https://api.simonjamesrowe.com",
     gaTrackingToken: window.GA_TRACKING_TOKEN || import.meta.env.VITE_GA_TRACKING_TOKEN || "UA-179384022-3",
-    hotJarTrackingToken: window.HOT_JAR_TRACKING_TOKEN || import.meta.env.VITE_HOTJAR_ID || "2022739",
-    environment: window.ENVIRONMENT || import.meta.env.VITE_ELASTIC_APM_ENVIRONMENT || "local",
-    apmUrl: window.APM_URL || import.meta.env.VITE_ELASTIC_APM_SERVER_URL || "https://apm.simonjamesrowe.com"
+    hotJarTrackingToken: window.HOT_JAR_TRACKING_TOKEN || import.meta.env.VITE_HOTJAR_ID || "2022739"
 }
 
 export {properties};

--- a/src/services/SkillsService.tsx
+++ b/src/services/SkillsService.tsx
@@ -14,14 +14,13 @@ export const getAllSkills: ActionCreator<
     const response = await axios.get<ISkillGroup[]>(
         `${properties.apiUrl}/skills-groups?_sort=order:asc`
     );
-    const skillsGroupsFromApi : ISkillGroup[] = response.data
-    skillsGroupsFromApi.forEach(skillGroup => {
-      skillGroup.skills = skillGroup.skills.sort((a,b) => a.order - b.order);
-    });
+    const skillsGroupsFromApi : ISkillGroup[] = response.data.map(skillGroup => ({
+        ...skillGroup,
+        skills: [...skillGroup.skills].sort((a,b) => a.order - b.order)
+    }));
     dispatch({
       skillsGroups: skillsGroupsFromApi,
       type: SkillsActionTypes.GETALL
     });
   };
 };
-

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,10 +5,6 @@ interface ImportMetaEnv {
   readonly VITE_GA_TRACKING_TOKEN: string
   readonly VITE_HOTJAR_ID: string
   readonly VITE_HOTJAR_VERSION: string
-  readonly VITE_ELASTIC_APM_SERVICE_NAME: string
-  readonly VITE_ELASTIC_APM_SERVER_URL: string
-  readonly VITE_ELASTIC_APM_SERVICE_VERSION: string
-  readonly VITE_ELASTIC_APM_ENVIRONMENT: string
 }
 
 interface ImportMeta {
@@ -21,9 +17,5 @@ declare global {
     GA_TRACKING_TOKEN?: string;
     HOTJAR_ID?: string;
     HOTJAR_VERSION?: string;
-    ELASTIC_APM_SERVICE_NAME?: string;
-    ELASTIC_APM_SERVER_URL?: string;
-    ELASTIC_APM_SERVICE_VERSION?: string;
-    ELASTIC_APM_ENVIRONMENT?: string;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,30 +207,6 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@elastic/apm-rum-core@^5.23.0":
-  version "5.23.0"
-  resolved "https://registry.yarnpkg.com/@elastic/apm-rum-core/-/apm-rum-core-5.23.0.tgz#45f463afc14272de83af3a41e369a677b54334b6"
-  integrity sha512-kQnKwf6EaHfNvOrL66SOJuoAp8xuCdqAGb/bnxiKsFu1DKYOglJiW5Su4wSjQp82rTP7Vt2X1RZbu+7lURLX9Q==
-  dependencies:
-    error-stack-parser "^1.3.5"
-    opentracing "^0.14.3"
-    promise-polyfill "^8.1.3"
-
-"@elastic/apm-rum-react@^2.0.2":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@elastic/apm-rum-react/-/apm-rum-react-2.0.6.tgz#9e9d06cbd9c6ad0d9f65a3b6d2bcaccd75211075"
-  integrity sha512-aOk6Dt8fuy7iBlEmzyi7DN0XO+ucr0SjHZdxZmLL/o2O4dOvvBdfuwEBPxFKI6QbNgxb2ZS4QRMGHqGu7bgmhA==
-  dependencies:
-    "@elastic/apm-rum" "^5.17.0"
-    hoist-non-react-statics "^3.3.0"
-
-"@elastic/apm-rum@^5.16.0", "@elastic/apm-rum@^5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@elastic/apm-rum/-/apm-rum-5.17.0.tgz#5f1927f28e1b45cac53c504457e5be76d37f0f79"
-  integrity sha512-e1qz79MQfSBUTlsKcAGbCyn21iARSJA6t300BGATIn+h41EMhFTgKGLT+Nk3kvQ548mx596FrOQsHLg6E/OmeQ==
-  dependencies:
-    "@elastic/apm-rum-core" "^5.23.0"
-
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
@@ -604,6 +580,25 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@modelcontextprotocol/sdk@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.21.1.tgz#8fba02e7581d49cc9b047aab0cfd334043321fe5"
+  integrity sha512-UyLFcJLDvUuZbGnaQqXFT32CpPpGj7VS19roLut6gkQVhb439xUzYWbsUvdI3ZPL+2hnFosuugtYWE0Mcs1rmQ==
+  dependencies:
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.0.1"
+    express-rate-limit "^7.5.0"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.23.8"
+    zod-to-json-schema "^3.24.1"
 
 "@mui/core-downloads-tracker@^7.3.2":
   version "7.3.2"
@@ -1388,6 +1383,14 @@
     loupe "^2.3.7"
     pretty-format "^29.7.0"
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -1413,6 +1416,13 @@ acorn@^8.11.0, acorn@^8.15.0, acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1422,6 +1432,16 @@ ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -1524,6 +1544,21 @@ body-parser@1.20.3:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+body-parser@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.0.tgz#f7a9656de305249a715b549b7b8fd1ab9dfddcfa"
+  integrity sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.0"
+    http-errors "^2.0.0"
+    iconv-lite "^0.6.3"
+    on-finished "^2.4.1"
+    qs "^6.14.0"
+    raw-body "^3.0.0"
+    type-is "^2.0.0"
+
 bootstrap@^5.3.3:
   version "5.3.8"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
@@ -1562,7 +1597,7 @@ browserslist@^4.24.0:
     node-releases "^2.0.21"
     update-browserslist-db "^1.1.3"
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -1753,15 +1788,22 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
+content-disposition@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.0.tgz#844426cb398f934caefcbb172200126bc7ceace2"
+  integrity sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@^1.0.5, content-type@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-content-type@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
-  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^1.5.0:
   version "1.9.0"
@@ -1778,10 +1820,28 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -1794,7 +1854,7 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1832,7 +1892,7 @@ debug@^4.0.0, debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1868,7 +1928,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-depd@2.0.0:
+depd@2.0.0, depd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -1952,20 +2012,25 @@ electron-to-chromium@^1.5.218:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz#921042a011a98a4620853c9d391ab62bcc124400"
   integrity sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==
 
+encodeurl@^2.0.0, encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encodeurl@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
-  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
-
 entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1973,13 +2038,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^1.3.5:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
-  integrity sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=
-  dependencies:
-    stackframe "^0.3.1"
 
 es-define-property@^1.0.1:
   version "1.0.1"
@@ -2042,7 +2100,7 @@ escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -2179,10 +2237,22 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@~1.8.1:
+etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
+  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 execa@^8.0.1:
   version "8.0.1"
@@ -2198,6 +2268,11 @@ execa@^8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
+
+express-rate-limit@^7.5.0:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
+  integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
 
 express@^4.19.2:
   version "4.21.2"
@@ -2236,6 +2311,39 @@ express@^4.19.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.1.0.tgz#d31beaf715a0016f0d53f47d3b4d7acf28c75cc9"
+  integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.0"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
+
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -2266,6 +2374,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -2312,6 +2425,18 @@ finalhandler@1.3.1:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+finalhandler@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.0.tgz#72306373aa89d05a8242ed569ed86a1bff7c561f"
+  integrity sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -2384,6 +2509,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2532,10 +2662,50 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
 
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
@@ -2558,6 +2728,19 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz#477cd42d278d4f036bc2ea58586130f6f39ee6ed"
+  integrity sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
@@ -2575,6 +2758,17 @@ hastscript@^6.0.0:
     hast-util-parse-selector "^2.0.0"
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 highlight.js@^10.4.1, highlight.js@~10.6.0:
   version "10.6.0"
@@ -2598,7 +2792,12 @@ html-url-attributes@^3.0.0:
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
 
-http-errors@2.0.0:
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+
+http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
   integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
@@ -2620,6 +2819,20 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.0.tgz#c50cd80e6746ca8115eb98743afa81aa0e147a3e"
+  integrity sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
@@ -2776,6 +2989,11 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
 is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
@@ -2827,6 +3045,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3139,10 +3362,20 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 merge-descriptors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3450,12 +3683,24 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.12, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
+
+mime-types@^3.0.0, mime-types@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.1.tgz#b1d94d6997a9b32fd69ebaed0db73de8acb519ce"
+  integrity sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime-types@~2.1.34:
   version "2.1.35"
@@ -3545,6 +3790,11 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
 node-releases@^2.0.21:
   version "2.0.21"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.21.tgz#f59b018bc0048044be2d4c4c04e4c8b18160894c"
@@ -3557,7 +3807,7 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3567,14 +3817,14 @@ object-inspect@^1.13.3:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -3587,11 +3837,6 @@ onetime@^6.0.0:
   integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
   dependencies:
     mimic-fn "^4.0.0"
-
-opentracing@^0.14.3:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.5.tgz#891fa92cd90a24e64f99bc964370227310926c85"
-  integrity sha512-XLKtEfHxqrWyF1fzxznsv78w3csW41ucHnjiKnfzZLD5FN8UBDZZL1i4q0FR29zjxXhm+2Hop+5Vr/b8tKIvEg==
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -3668,7 +3913,14 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
-parseurl@~1.3.3:
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
+parseurl@^1.3.3, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -3703,6 +3955,11 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
+path-to-regexp@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.3.0.tgz#aa818a6981f99321003a08987d3cec9c3474cd1f"
+  integrity sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -3732,6 +3989,11 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pkce-challenge@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz#c3a405cb49e272094a38e890a2b51da0228c4d97"
+  integrity sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==
 
 pkg-types@^1.2.1, pkg-types@^1.3.1:
   version "1.3.1"
@@ -3775,11 +4037,6 @@ prismjs@~1.27.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
-promise-polyfill@^8.1.3:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
-  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
-
 prop-types-extra@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
@@ -3813,12 +4070,17 @@ property-information@^5.0.0:
   dependencies:
     xtend "^4.0.0"
 
+property-information@^6.0.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
+  integrity sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==
+
 property-information@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
@@ -3843,12 +4105,19 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
+qs@^6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
+  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+  dependencies:
+    side-channel "^1.1.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-range-parser@~1.2.1:
+range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
@@ -3861,6 +4130,16 @@ raw-body@2.5.2:
     bytes "3.1.2"
     http-errors "2.0.0"
     iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.1.tgz#ced5cd79a77bbb0496d707f2a0f9e1ae3aecdcb1"
+  integrity sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.7.0"
     unpipe "1.0.0"
 
 react-async-script@^1.2.0:
@@ -4089,6 +4368,15 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
+
 remark-gfm@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
@@ -4130,6 +4418,11 @@ remark-stringify@^11.0.0:
     "@types/mdast" "^4.0.0"
     mdast-util-to-markdown "^2.0.0"
     unified "^11.0.0"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 reselect@^5.1.0:
   version "5.1.1"
@@ -4192,6 +4485,17 @@ rollup@^4.20.0:
     "@rollup/rollup-win32-x64-msvc" "4.50.1"
     fsevents "~2.3.2"
 
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -4204,7 +4508,7 @@ safe-buffer@5.2.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4252,6 +4556,23 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+send@^1.1.0, send@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.0.tgz#32a7554fb777b831dfa828370f773a3808d37212"
+  integrity sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==
+  dependencies:
+    debug "^4.3.5"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    mime-types "^3.0.1"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.1"
+
 serve-static@1.16.2:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.2.tgz#b6a5343da47f6bdd2673848bf45754941e803296"
@@ -4261,6 +4582,16 @@ serve-static@1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
+
+serve-static@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.0.tgz#9c02564ee259bdd2251b82d659a2e7e1938d66f9"
+  integrity sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -4308,7 +4639,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.6:
+side-channel@^1.0.6, side-channel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
   integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
@@ -4368,15 +4699,15 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
-stackframe@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
-  integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
-
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+statuses@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 std-env@^3.5.0:
   version "3.9.0"
@@ -4537,6 +4868,15 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+type-is@^2.0.0, type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -4656,10 +4996,18 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
 
 vfile-message@^4.0.0:
   version "4.0.3"
@@ -4732,6 +5080,11 @@ warning@^4.0.0, warning@^4.0.1, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -4791,6 +5144,16 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+zod-to-json-schema@^3.24.1:
+  version "3.24.6"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
+  integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
+
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Summary
- drops the Elastic APM wiring and adds a safer runtime API URL fallback so deployments can override /environment/config.js
- updates markdown rendering to the current react-markdown API with shared code block/external link components and rehype-raw
- cleans up various UI components (site search, resume, contact, social links) to avoid React warnings and improve navigation/accessibility
- documents the repo workflow expectations in AGENTS.md for MCP-powered agents

## Testing
- Not run (per request)
