### PR TITLE
[FEAT] Boost Take a tour visibility

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -870,6 +870,26 @@ div.align-right  div {
     float: right;
 }
 
+.take-tour-chip {
+    background: #ff9f1c !important;
+    color: #222222 !important;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    border-radius: 24px;
+    padding: 0 6px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.take-tour-chip:hover {
+    background: #ffb347 !important;
+    color: #1a1a1a !important;
+}
+
+.take-tour-chip .MuiChip-icon {
+    color: inherit;
+}
+
 .bannner_leftpart span.stran {
     color: #222222;
 }

--- a/src/components/pages/Home/Headline.tsx
+++ b/src/components/pages/Home/Headline.tsx
@@ -55,7 +55,7 @@ const Headline = ({ profile, mobile, searchQuery, startSimulation }: IHeadlinePr
                         icon={<AirplanemodeActiveIcon />}
                         label="Take a tour"
                         onClick={invokeTour}
-
+                        className="take-tour-chip"
                     />
                 </div>
                 )}
@@ -117,4 +117,3 @@ export default connect(
     mapStateToProps,
     mapDispatchToProps
 )(Headline);
-


### PR DESCRIPTION
## Summary
- Add a custom class to the Take a tour Chip and style it with brighter accent colors and a hover state.
- Give the Chip stronger typography plus a subtle shadow so it stands out against busy hero imagery.

## Deployment Notes
- None.

## Screenshots / Payloads (when relevant)
- N/A
